### PR TITLE
Enable AMP and compile in PPO training

### DIFF
--- a/ppo/train.py
+++ b/ppo/train.py
@@ -3,6 +3,7 @@ import argparse
 import torch
 import torch.optim as optim
 from torch.nn import functional as F
+from torch.amp import autocast, GradScaler
 import time
 from collections import deque
 from tqdm import tqdm
@@ -26,6 +27,10 @@ else:
 os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
 os.environ["JAX_DEFAULT_MATMUL_PRECISION"] = "highest"
 os.environ['XLA_FLAGS'] = "--xla_gpu_triton_gemm_any=True" # Enable triton gemm
+
+import torch._dynamo
+torch.set_float32_matmul_precision("high")
+torch._dynamo.config.suppress_errors = True
 
 
 def make_parser():
@@ -52,12 +57,26 @@ def make_parser():
     parser.add_argument("--exp-name", type=str, default="ppo", help="Experiment name")
     parser.add_argument("--seed", type=int, default=1, help="Random seed")
     parser.add_argument("--max-grad-norm", type=float, default=1.0, help="Maximum gradient norm for clipping")
+    parser.add_argument("--compile", action="store_true", help="Use torch.compile for key functions")
+    parser.add_argument("--amp", action="store_true", help="Enable automatic mixed precision")
+    parser.add_argument(
+        "--amp-dtype",
+        type=str,
+        default="bf16",
+        choices=["bf16", "fp16"],
+        help="Precision to use for AMP (bf16 or fp16)",
+    )
     return parser
 
 
 def main():
     args = make_parser().parse_args()
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    amp_enabled = args.amp and torch.cuda.is_available()
+    amp_device_type = "cuda" if torch.cuda.is_available() else "cpu"
+    amp_dtype = torch.bfloat16 if args.amp_dtype == "bf16" else torch.float16
+    scaler = GradScaler(enabled=amp_enabled and amp_dtype == torch.float16)
     
     # Set random seeds
     torch.manual_seed(args.seed)
@@ -101,6 +120,17 @@ def main():
     optimizer = optim.Adam(policy.parameters(), lr=args.learning_rate)
     normalizer = EmpiricalNormalization(shape=n_obs, device=device)
 
+    if args.compile:
+        policy_act = torch.compile(policy.act)
+        policy_value = torch.compile(policy.value)
+        policy_get_dist = torch.compile(policy.get_dist)
+        normalize_obs = torch.compile(normalizer.forward)
+    else:
+        policy_act = policy.act
+        policy_value = policy.value
+        policy_get_dist = policy.get_dist
+        normalize_obs = normalizer.forward
+
     buffer = RolloutBuffer(args.rollout_length, args.num_envs, n_obs, n_act, device=device)
     
     # Progress tracking variables
@@ -136,9 +166,9 @@ def main():
         # Run for a fixed number of steps
         max_steps = getattr(eval_envs, 'max_episode_length', getattr(eval_envs, 'max_episode_steps', 1000))
         for _ in range(max_steps):
-            with torch.no_grad():
-                norm_obs = normalizer(obs)
-                action, _, _ = policy.act(norm_obs)
+            with torch.no_grad(), autocast(device_type=amp_device_type, dtype=amp_dtype, enabled=amp_enabled):
+                norm_obs = normalize_obs(obs)
+                action, _, _ = policy_act(norm_obs)
 
             next_obs, rewards, dones, _ = eval_envs.step(action)
             episode_returns = torch.where(
@@ -172,9 +202,9 @@ def main():
             render_env.state.info["command"] = jnp.array([[1.0, 0.0, 0.0]])
             renders = [render_env.state]
         for i in range(render_env.max_episode_steps):
-            with torch.no_grad():
-                norm_obs = normalizer(obs)
-                action, _, _ = policy.act(norm_obs)
+            with torch.no_grad(), autocast(device_type=amp_device_type, dtype=amp_dtype, enabled=amp_enabled):
+                norm_obs = normalize_obs(obs)
+                action, _, _ = policy_act(norm_obs)
             next_obs, _, done, _ = render_env.step(action)
             if env_type == "mujoco_playground":
                 render_env.state.info["command"] = jnp.array([[1.0, 0.0, 0.0]])
@@ -234,9 +264,9 @@ def main():
             # Data collection phase
             rollout_start_time = time.time()
             for step in tqdm(range(args.rollout_length), desc="Data Collection", leave=False):
-                norm_obs = normalizer(obs)
-                with torch.no_grad():
-                    action, logp, value = policy.act(norm_obs)
+                with torch.no_grad(), autocast(device_type=amp_device_type, dtype=amp_dtype, enabled=amp_enabled):
+                    norm_obs = normalize_obs(obs)
+                    action, logp, value = policy_act(norm_obs)
                 next_obs, reward, done, _ = envs.step(action)
                 # Add each environment's transition to buffer
                 buffer.add(
@@ -269,8 +299,8 @@ def main():
             rollout_time = time.time() - rollout_start_time
             
             # Compute advantages - handle each environment separately
-            with torch.no_grad():
-                last_values = policy.value(normalizer(obs))  # Shape: [num_envs]
+            with torch.no_grad(), autocast(device_type=amp_device_type, dtype=amp_dtype, enabled=amp_enabled):
+                last_values = policy_value(normalize_obs(obs))  # Shape: [num_envs]
             # Compute advantages for each environment's data separately
             buffer.compute_returns_and_advantage(last_values, args.gamma, args.gae_lambda, args.num_envs)
 
@@ -283,35 +313,37 @@ def main():
             
             for epoch in tqdm(range(args.update_epochs), desc="Policy Updates", leave=False):
                 for b_obs, b_actions, b_logp, b_returns, b_adv in buffer.get_batches(args.batch_size):
-                    dist = policy.get_dist(normalizer(b_obs))
-                    
-                    # Since b_actions are tanh-transformed, we need to inverse them
-                    # and compute log prob with Jacobian correction
-                    raw_actions = torch.atanh(torch.clamp(b_actions, -0.999, 0.999))
-                    new_logp = dist.log_prob(raw_actions).sum(-1)
-                    # Apply tanh Jacobian correction
-                    new_logp = new_logp - (2 * (torch.log(torch.tensor(2.0)) - raw_actions - torch.nn.functional.softplus(-2 * raw_actions))).sum(-1)
-                    
-                    ratio = (new_logp - b_logp).exp()
-                    pg_loss1 = -b_adv * ratio
-                    pg_loss2 = -b_adv * torch.clamp(ratio, 1 - args.clip_eps, 1 + args.clip_eps)
-                    policy_loss = torch.max(pg_loss1, pg_loss2).mean()
+                    with autocast(device_type=amp_device_type, dtype=amp_dtype, enabled=amp_enabled):
+                        dist = policy_get_dist(normalize_obs(b_obs))
 
-                    value = policy.value(normalizer(b_obs))
-                    value_loss = F.mse_loss(value, b_returns)
-                    entropy = dist.entropy().sum(-1).mean()
+                        # Since b_actions are tanh-transformed, we need to inverse them
+                        raw_actions = torch.atanh(torch.clamp(b_actions, -0.999, 0.999))
+                        new_logp = dist.log_prob(raw_actions).sum(-1)
+                        # Apply tanh Jacobian correction
+                        new_logp = new_logp - (2 * (torch.log(torch.tensor(2.0)) - raw_actions - torch.nn.functional.softplus(-2 * raw_actions))).sum(-1)
 
-                    loss = policy_loss + args.vf_coef * value_loss - args.ent_coef * entropy
+                        ratio = (new_logp - b_logp).exp()
+                        pg_loss1 = -b_adv * ratio
+                        pg_loss2 = -b_adv * torch.clamp(ratio, 1 - args.clip_eps, 1 + args.clip_eps)
+                        policy_loss = torch.max(pg_loss1, pg_loss2).mean()
+
+                        value = policy_value(normalize_obs(b_obs))
+                        value_loss = F.mse_loss(value, b_returns)
+                        entropy = dist.entropy().sum(-1).mean()
+
+                        loss = policy_loss + args.vf_coef * value_loss - args.ent_coef * entropy
                     optimizer.zero_grad()
-                    loss.backward()
+                    scaler.scale(loss).backward()
+                    scaler.unscale_(optimizer)
                     
                     # Apply gradient clipping
                     grad_norm = torch.nn.utils.clip_grad_norm_(
                         policy.parameters(),
                         max_norm=args.max_grad_norm if args.max_grad_norm > 0 else float("inf"),
                     )
-                    
-                    optimizer.step()
+
+                    scaler.step(optimizer)
+                    scaler.update()
                     
                     # Accumulate metrics
                     epoch_policy_loss += policy_loss.item()


### PR DESCRIPTION
## Summary
- add AMP and `torch.compile` options to PPO training script
- integrate `GradScaler` and `autocast` during rollout and update loops
- compile policy and normalizer functions when requested
